### PR TITLE
Fix compilation error

### DIFF
--- a/src/processor.hpp
+++ b/src/processor.hpp
@@ -4,9 +4,9 @@
 #include <filesystem>
 #include <string>
 #include <unordered_map>
+#include "test_component_set.hpp"
 
 class logger;
-class test_component_set;
 
 class processor
 {


### PR DESCRIPTION
It seems `test_component_set` must be fully specified as it is used as a
value of a map which is member of `processor`.